### PR TITLE
Fixed appID

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ var recipes = require('./recipes');
 
 exports.handler = function(event, context, callback) {
     var alexa = Alexa.handler(event, context);
-    alexa.APP_ID = APP_ID;
+    alexa.appID = APP_ID;
     // To enable string internationalization (i18n) features, set a resources object.
     alexa.resources = languageStrings;
     alexa.registerHandlers(handlers);


### PR DESCRIPTION
alexa.APP_ID doesn't work, causing "Application ID not set" warnings. The correct property is appID.