### PR TITLE
"The skill's invocation name should not contain any connecting words"

### DIFF
--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -237,7 +237,7 @@ const languageStrings = {
   'de': {
     translation: {
       RECIPES: recipes.RECIPE_DE_DE,
-      SKILL_NAME: 'Assistent für Minecraft in Deutsch',
+      SKILL_NAME: 'Minecraft Assistent in Deutsch',
       WELCOME_MESSAGE: 'Willkommen bei %s. Du kannst beispielsweise die Frage stellen: Welche Rezepte gibt es für eine %s? ... Nun, womit kann ich dir helfen?',
       WELCOME_REPROMPT: 'Wenn du wissen möchtest, was du sagen kannst, sag einfach „Hilf mir“.',
       DISPLAY_CARD_TITLE: '%s - Rezept für %s.',

--- a/models/de-DE.json
+++ b/models/de-DE.json
@@ -1,7 +1,7 @@
 {
   "interactionModel": {
     "languageModel": {
-      "invocationName": "assistent für minecraft",
+      "invocationName": "minecraft assistent",
       "intents": [
         {
           "name": "RecipeIntent",

--- a/skill.json
+++ b/skill.json
@@ -17,7 +17,7 @@
           "description": "Sample Full Description"
         },
         "de-DE": {
-          "name": "Assistent für Minecraft in Deutsch"
+          "name": "Minecraft Assistent in Deutsch"
         },
         "en-GB": {
           "name": "British Minecraft Helper"


### PR DESCRIPTION
The German invocation name of the skill is currently **assistent für minecraft**. According to automated validation, connecting words like **für** should not be used. Although according to [Invocation Name Requirements](https://developer.amazon.com/de-DE/docs/alexa/custom-skills/choose-the-invocation-name-for-a-custom-skill.html#cert-invocation-name-req) this only applies to two-word invocation names, it might be better to change it anyway.

*Description of changes:*
I changed every occurrence of **Assistent für Minecraft** to **Minecraft Assistent**.